### PR TITLE
Add UQRoo

### DIFF
--- a/lib/domains/mx/edu/uqroo.txt
+++ b/lib/domains/mx/edu/uqroo.txt
@@ -1,0 +1,2 @@
+Universidad Autónoma del Estado de Quintana Roo
+Autonomous University of Quintana Roo State


### PR DESCRIPTION
++ the school official website URL:   https://www.uqroo.mx/
++ the school street address, including city and country:  Campus Chetumal Bahía, Boulevard Bahía s/n esq. Ignacio Comonfort Col. Del Bosque. C.P. 77019 Chetumal, Quintana Roo, México
++ an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course:  https://www.uqroo.mx/portal-nuevo/oferta-academica/licenciaturas/?carrera=LIRB

Teachers domain: @uqroo.edu.mx
Students domain: @uqroo.mx